### PR TITLE
new method thread:interrupt()

### DIFF
--- a/src/lua/llthreads2/ex.lua
+++ b/src/lua/llthreads2/ex.lua
@@ -141,6 +141,15 @@ function thread_mt:joinable()
   return self.thread:joinable()
 end
 
+--- Interrupt thread
+-- The thread is interrupted by installing a debug hook that
+-- creates an error.
+-- @tparam ?boolean if not given, interrupt only once,
+--         otherwise this arg sets or unsets permanent interrupt.
+function thread_mt:interrupt(arg)
+  return self.thread:interrupt(arg)
+end
+
 end
 -------------------------------------------------------------------------------
 


### PR DESCRIPTION
Hi,

here comes a method to interrupt a thread using a debug hook similiar to the SIGINT signal handler of the original lua interpreter (see function laction in lua.c).

Best regards,
Oliver