### PR TITLE
avoid NULL as parameter to fputs()

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,6 +58,7 @@ script:
   - lua test_threads_attr.lua
   - lua test_integer.lua
   - lua test_interrupt.lua
+  - lua test_error.lua
   # - lua test_register_llthreads.lua
 
 notifications:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -73,6 +73,7 @@ test_script:
   - lua test_threads_attr.lua
   - lua test_integer.lua
   - lua test_interrupt.lua
+  - lua test_error.lua
   # - lua test_register_llthreads.lua
 
 after_test:

--- a/lakefile
+++ b/lakefile
@@ -45,6 +45,7 @@ target('test', install, function()
   run_test('test_threads_ex_opt_2.lua')
   run_test('test_threads_attr.lua')
   run_test('test_interrupt.lua')
+  run_test('test_error.lua')
 
 
   if not test_summary() then

--- a/src/llthread.c
+++ b/src/llthread.c
@@ -132,11 +132,12 @@ static int fail(lua_State *L, const char *msg){
 void llthread_log(lua_State *L, const char *hdr, const char *msg){
   int top = lua_gettop(L);
   lua_rawgetp(L, LUA_REGISTRYINDEX, LLTHREAD_LOGGER_HOLDER);
+  if (!msg) 
+    msg = "(no error message)";
   if(lua_isnil(L, -1)){
     lua_pop(L, 1);
     fputs(hdr,  stderr);
-    if (msg) fputs(msg,  stderr);
-    else     fputs("(no error message)",  stderr);
+    fputs(msg,  stderr);
     fputc('\n', stderr);
     fflush(stderr);
     return;

--- a/src/llthread.c
+++ b/src/llthread.c
@@ -135,7 +135,8 @@ void llthread_log(lua_State *L, const char *hdr, const char *msg){
   if(lua_isnil(L, -1)){
     lua_pop(L, 1);
     fputs(hdr,  stderr);
-    fputs(msg,  stderr);
+    if (msg) fputs(msg,  stderr);
+    else     fputs("(no error message)",  stderr);
     fputc('\n', stderr);
     fflush(stderr);
     return;

--- a/test/test_error.lua
+++ b/test/test_error.lua
@@ -5,13 +5,37 @@ local include = utils.thread_init .. [[
 local llthreads = require"llthreads"
 ]]
 
-local thread = llthreads.new(include .. [[
-  error({})
-]])
-
-thread:start()
-local ok, err = thread:join()
-print(ok, err)
-assert(not ok)
+do
+    local thread = llthreads.new(include .. [[
+      error({})
+    ]])
+    
+    thread:start()
+    local ok, err = thread:join()
+    print(ok, err)
+    assert(not ok)
+end
+do
+    local thread = llthreads.new(include .. [[
+      llthreads.set_logger(function(msg) print("XXX", msg) end)
+      error({})
+    ]])
+    
+    thread:start()
+    local ok, err = thread:join()
+    print(ok, err)
+    assert(not ok)
+end
+do
+    local thread = llthreads.new(include .. [[
+      llthreads.set_logger(function(msg) end)
+      error({})
+    ]])
+    
+    thread:start()
+    local ok, err = thread:join()
+    print(ok, err)
+    assert(not ok)
+end
 print("Done!")
 

--- a/test/test_error.lua
+++ b/test/test_error.lua
@@ -1,0 +1,17 @@
+local llthreads = require"llthreads"
+local utils     = require "utils"
+
+local include = utils.thread_init .. [[
+local llthreads = require"llthreads"
+]]
+
+local thread = llthreads.new(include .. [[
+  error({})
+]])
+
+thread:start()
+local ok, err = thread:join()
+print(ok, err)
+assert(not ok)
+print("Done!")
+


### PR DESCRIPTION
Passing NULL to `fputs()` crashes under Linux (I did not try this on other platforms).

This occurs for Lua 5.1 when a non string error is triggerd (e.g. table object): the traceback function for Lua 5.1 in `traceback.inc` pushes `nil` onto the stack, whereas for other Lua versions the `__tostring` metamethod is tried and otherwise the string `"(no error message)"` is pushed.

I simply put an `if (msg)` around the `fputs()` invocation, however other solutions might be better, e.g. trying also to evaluate the `__tostring` meta method as it is done for newer lua versions.