### PR TITLE
Avoid duplicate symbol when linking against luajit

### DIFF
--- a/src/l52util.c
+++ b/src/l52util.c
@@ -22,6 +22,7 @@ void luaL_register (lua_State *L, const char *libname, const luaL_Reg *l){
 
 #else 
 
+#ifndef LUA_LJDIR
 void luaL_setfuncs (lua_State *L, const luaL_Reg *l, int nup){
   luaL_checkstack(L, nup, "too many upvalues");
   for (; l->name != NULL; l++) {  /* fill the table with given functions */
@@ -33,6 +34,7 @@ void luaL_setfuncs (lua_State *L, const luaL_Reg *l, int nup){
   }
   lua_pop(L, nup);  /* remove upvalues */
 }
+#endif
 
 void lua_rawgetp(lua_State *L, int index, const void *p){
   index = lua_absindex(L, index);

--- a/src/l52util.h
+++ b/src/l52util.h
@@ -48,7 +48,9 @@ void luaL_register (lua_State *L, const char *libname, const luaL_Reg *l);
 
 void  lua_rawgetp   (lua_State *L, int index, const void *p);
 void  lua_rawsetp   (lua_State *L, int index, const void *p);
+#ifndef LUA_LJDIR
 void  luaL_setfuncs  (lua_State *L, const luaL_Reg *l, int nup);
+#endif
 
 void lutil_require(lua_State *L, const char* name, lua_CFunction fn, int glb);
 


### PR DESCRIPTION
This PR fixes static linking against luajit,
which would before result in multiple definitions of the symbol `luaL_setfuncs()`.